### PR TITLE
Add configuration options for connecting to SSL-secured LDAP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ plugins:
   auth-ldap:
     uri: "ldap://ldap.example.org"
 
+    # Path to CA certificates to use when connecting to
+    # SSL-secured LDAP servers. If not specified, it will use
+    # a default set of well-known CAs.
+    ca_certificates:
+        - /path/to/ca_cert.pem
+        - /path/to/another/ca_cert.pem
+
+    # Check the validity of the server's certificate. Useful
+    # when connecting to servers that use a self-signed certificate.
+    # Defaults to true if not specified.
+    check_certificate: true
+
     # Credentials to use before looking for the user record.
     #
     # Default to anonymous.

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,8 @@ class AuthLdap {
   constructor (conf) {
     const clientOpts = {
       url: conf.uri,
-      maxConnections: 5
+      maxConnections: 5,
+      tlsOptions: { }
     }
 
     {
@@ -35,6 +36,10 @@ class AuthLdap {
         clientOpts.bindDN = bind.dn
         clientOpts.bindCredentials = bind.password
       }
+    }
+
+    if (conf.check_certificate !== undefined) {
+      clientOpts.tlsOptions.rejectUnauthorized = conf.check_certificate
     }
 
     const {base: searchBase} = conf

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,10 @@ class AuthLdap {
       clientOpts.tlsOptions.rejectUnauthorized = conf.check_certificate
     }
 
+    if (conf.ca_certificates !== undefined) {
+      clientOpts.tlsOptions.ca = conf.ca_certificates
+    }
+
     const {base: searchBase} = conf
     const searchFilter = conf.filter || '(uid={{name}})'
 


### PR DESCRIPTION
This adds the ability to specify the path to your trusted CA certificates, or disable checking the validity of the server's certificate (useful when using self-signed certificates on your LDAP server).

I'm not a CoffeeScript guy, so let me know if anything needs changing - hopefully I got it right on the first try.
