### PR TITLE
Fix npm scripts on OS X

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "standard": "*"
   },
   "scripts": {
-    "build": "mkdir --parents dist && babel --optional=runtime --compact=true --source-maps --out-dir=dist/ src/",
-    "dev": "mkdir --parents dist && babel --watch --optional=runtime --compact=true --source-maps --out-dir=dist/ src/",
+    "build": "mkdir -p dist && babel --optional=runtime --compact=true --source-maps --out-dir=dist/ src/",
+    "dev": "mkdir -p dist && babel --watch --optional=runtime --compact=true --source-maps --out-dir=dist/ src/",
     "prepublish": "npm build",
     "test": "standard && npm run build && mocha 'dist/**/*.spec.js'",
     "test-dev": "standard && mocha --watch --reporter=min 'dist/**/*.spec.js'"


### PR DESCRIPTION
BSD mkdir doesn't support the long `--parents` flag; changing to the short-form `-p` flag allows the scripts to run on OS X.
